### PR TITLE
feat(backend, logger): selector of logger precision

### DIFF
--- a/backend/cmd/config.go
+++ b/backend/cmd/config.go
@@ -46,6 +46,10 @@ type TCP struct {
 	KeepAlive         int     `toml:"keep_alive_ms"`
 }
 
+type Logging struct {
+	TimeUnit string `toml:"time_unit"`
+}
+
 type Config struct {
 	App       App
 	Vehicle   vehicle.Config
@@ -56,4 +60,5 @@ type Config struct {
 	TFTP      TFTP
 	TCP       TCP
 	Blcu      Blcu
+	Logging   Logging
 }

--- a/backend/cmd/config.toml
+++ b/backend/cmd/config.toml
@@ -52,6 +52,9 @@ timeout_ms = 5000      # Timeout between retries in milliseconds
 backoff_factor = 2     # Backoff multiplier for retry delays
 enable_progress = true # Enable progress callbacks during transfers
 
+# Logger Configuration
+time_unit = "us"      # Time unit for log timestamps (ns, us, ms, s)  Default: ns
+
 # <-- DO NOT TOUCH BELOW THIS LINE -->
 
 # Server Configuration

--- a/backend/cmd/dev-config.toml
+++ b/backend/cmd/dev-config.toml
@@ -85,3 +85,4 @@ file = "backend.log" # Log file path (empty to disable file logging)
 max_size_mb = 100    # Maximum log file size in MB
 max_backups = 3      # Number of backup files to keep
 max_age_days = 7     # Maximum age of log files in days
+time_unit = "us"      # Time unit for log timestamps (ns, us, ms, s)    

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -48,8 +48,8 @@ import (
 	state_logger "github.com/HyperloopUPV-H8/h9-backend/pkg/logger/state"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/sniffer"
-	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/udp"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/tcp"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/udp"
 	blcu_packet "github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet/blcu"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet/data"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet/order"
@@ -92,7 +92,7 @@ var currentVersion string
 func main() {
 	// Parse command line flags
 	flag.Parse()
-	
+
 	// Handle version flag
 	if *versionFlag {
 		versionFile := "VERSION.txt"
@@ -104,7 +104,7 @@ func main() {
 		}
 		os.Exit(0)
 	}
-	
+
 	// update() // FIXME: Updater disabled due to cross-platform and reliability issues
 
 	traceFile := initTrace(*traceLevel, *traceFile)
@@ -184,6 +184,7 @@ func main() {
 		state_logger.Name:      state_logger.NewLogger(),
 	}
 
+	logger.SetFormatTimestamp(logger.TimeUnit(config.Logging.TimeUnit)) // MUST be before creating subloggers
 	loggerHandler := logger.NewLogger(subloggers, trace.Logger)
 
 	// <--- order transfer --->

--- a/backend/pkg/logger/data/logger.go
+++ b/backend/pkg/logger/data/logger.go
@@ -71,7 +71,7 @@ func (sublogger *Logger) Start() error {
 		return nil
 	}
 
-	sublogger.startTime = time.Now().UnixMicro() // Update the start time
+	sublogger.startTime = loggerHandler.FormatTimestamp(time.Now()) // Update the start time
 
 	fmt.Println("Logger started")
 	return nil
@@ -125,7 +125,7 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 		}
 
 		err = saveFile.Write([]string{
-			fmt.Sprint(dataRecord.Packet.Timestamp().UnixMicro() - sublogger.startTime), // Save the timestamp relative to the start time
+			fmt.Sprint(loggerHandler.FormatTimestamp(dataRecord.Packet.Timestamp()) - sublogger.startTime), // Save the timestamp relative to the start time
 			dataRecord.From,
 			dataRecord.To,
 			valueRepresentation,
@@ -144,10 +144,12 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 	return writeErr
 }
 
+// Checks if the file for the given valueName exists, and creates it if it doesn't
 func (sublogger *Logger) getFile(valueName data.ValueName, board string) (*file.CSV, error) {
 	sublogger.fileLock.Lock()
 	defer sublogger.fileLock.Unlock()
 
+	// Check if the file already exists
 	valueFile, ok := sublogger.saveFiles[valueName]
 	if ok {
 		return valueFile, nil
@@ -159,6 +161,7 @@ func (sublogger *Logger) getFile(valueName data.ValueName, board string) (*file.
 	return sublogger.saveFiles[valueName], err
 }
 
+// createFile creates the file for the given valueName and board, creating all necessary directories
 func (sublogger *Logger) createFile(valueName data.ValueName, board string) (*os.File, error) {
 	filename := path.Join(
 		"logger",

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -12,7 +12,7 @@ import (
 const (
 	Name            = "loggerHandler"
 	HandlerName     = "logger"
-  TimestampFormat = "02-Jan-2006_15-04-05.000"
+	TimestampFormat = "02-Jan-2006_15-04-05.000"
 )
 
 // Logger is a struct that implements the abstraction.Logger interface

--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -77,8 +77,8 @@ func TestLogger(t *testing.T) {
 		t.Error(err)
 	}
 
-	if output[0] != fmt.Sprint(dataPacketTime.UnixMicro()) || output[1] != "test" || output[2] != "test" || output[3] != "true" {
-		t.Errorf("dataErr: expected [%v test test true], got %v", timestamp.UnixMicro(), output)
+	if output[0] != fmt.Sprint(logger.FormatTimestamp(dataPacketTime)) || output[1] != "test" || output[2] != "test" || output[3] != "true" {
+		t.Errorf("dataErr: expected [%v test test true], got %v", logger.FormatTimestamp(timestamp), output)
 	}
 
 	// Order
@@ -111,7 +111,7 @@ func TestLogger(t *testing.T) {
 		t.Error(err)
 	}
 
-	if output[0] != fmt.Sprint(orderPacketTime.UnixMicro()) || output[1] != "test" || output[2] != "test" {
+	if output[0] != fmt.Sprint(logger.FormatTimestamp(orderPacketTime)) || output[1] != "test" || output[2] != "test" {
 		t.Errorf("orderErr: expected [test test], got %v", output)
 	}
 
@@ -163,7 +163,7 @@ func TestLogger(t *testing.T) {
 		t.Error(err)
 	}
 
-	if output[0] != fmt.Sprint(timestamp.UnixMicro()) || output[1] != "test" || output[2] != "test" || output[3] != "0" || output[4] != "7" || output[5] != "3" || output[6] != "test" || output[7] != "&{0 0}" || output[8] != protectionPacketTime.Format(time.RFC3339) {
+	if output[0] != fmt.Sprint(logger.FormatTimestamp(timestamp)) || output[1] != "test" || output[2] != "test" || output[3] != "0" || output[4] != "7" || output[5] != "3" || output[6] != "test" || output[7] != "&{0 0}" || output[8] != protectionPacketTime.Format(time.RFC3339) {
 		t.Errorf("orderErr: expected [test test 0], got %v", output)
 	}
 

--- a/backend/pkg/logger/order/logger.go
+++ b/backend/pkg/logger/order/logger.go
@@ -55,7 +55,7 @@ func (sublogger *Logger) Start() error {
 		return err
 	}
 
-	sublogger.startTime = time.Now().UnixMicro() // Update the start time
+	sublogger.startTime = logger.FormatTimestamp(time.Now()) // Update the start time
 
 	sublogger.writer = file.NewCSV(fileRaw)
 
@@ -102,7 +102,7 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 	}
 
 	err := sublogger.writer.Write([]string{
-		fmt.Sprint(orderRecord.Packet.Timestamp().UnixMicro() - sublogger.startTime),
+		fmt.Sprint(logger.FormatTimestamp(orderRecord.Packet.Timestamp()) - sublogger.startTime),
 		orderRecord.From,
 		orderRecord.To,
 		fmt.Sprint(orderRecord.Packet.Id()),

--- a/backend/pkg/logger/protection/logger.go
+++ b/backend/pkg/logger/protection/logger.go
@@ -57,7 +57,7 @@ func (sublogger *Logger) Start() error {
 		return nil
 	}
 
-	sublogger.startTime = time.Now().UnixMicro() // Update the start time
+	sublogger.startTime = logger.FormatTimestamp(time.Now()) // Update the start time
 
 	fmt.Println("Logger started")
 	return nil
@@ -87,7 +87,7 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 	}
 
 	err = saveFile.Write([]string{
-		fmt.Sprint(infoRecord.Timestamp.UnixMicro() - sublogger.startTime),
+		fmt.Sprint(logger.FormatTimestamp(infoRecord.Timestamp) - sublogger.startTime),
 		infoRecord.From,
 		infoRecord.To,
 		fmt.Sprint(infoRecord.Packet.Id()),

--- a/backend/pkg/logger/time.go
+++ b/backend/pkg/logger/time.go
@@ -1,0 +1,38 @@
+package logger
+
+import (
+	"fmt"
+	"time"
+)
+
+type TimeUnit string
+
+const (
+	Nanoseconds  TimeUnit = "ns"
+	Microseconds TimeUnit = "us"
+	Milliseconds TimeUnit = "ms"
+	Seconds      TimeUnit = "s"
+)
+
+// Function used by all the subloggers to format timestamps according to the selected unit, by default is microseconds
+var FormatTimestamp = func(t time.Time) int64 { return t.UnixNano() }
+
+// SetTimestampUnit sets the global timestamp unit for all loggers applying functions as objects of first class
+
+func SetFormatTimestamp(unit TimeUnit) {
+
+	switch unit {
+	case Nanoseconds:
+		FormatTimestamp = func(t time.Time) int64 { return t.UnixNano() }
+	case Microseconds:
+		FormatTimestamp = func(t time.Time) int64 { return t.UnixMicro() }
+	case Milliseconds:
+		FormatTimestamp = func(t time.Time) int64 { return t.UnixMilli() }
+	case Seconds:
+		FormatTimestamp = func(t time.Time) int64 { return t.Unix() }
+	default:
+		fmt.Printf("Unknown time unit: %s.\n", unit)
+	}
+}
+
+// SetTimestampUnit sets the global timestamp unit for all loggers


### PR DESCRIPTION
Create a new variable at toml's file which allows to set the precision of the logger timestamp.

## Technical Details

Create a new file backend/pkg/logger/time.go that, by applying Go’s first-class function capabilities, defines a function to format timestamps according to the format specified in the TOML configuration file.


## Files modified

- `backend/cmd/config.go`: include new setting `time_unit`
- `backend/cmd/dev-config.toml`: add new setting
- `backend/cmd/main.go`: read `time_unit` from toml and set time unit
- `backend/pkg/logger`
    - `time.go`: implements new feature 
    - `logger.go`: format an import
    - `order/logger.go`, `data/logger.go` & `protection/logger.go`: obtain de time in the format specified on `time_unit`

### `time.go`

- FormatTimestamp function that given a `time.Time` returns time with the unit specified in `time_unit`
- SetFormatTimestamp given an string that corresponds with a unit, adjusts FormatTimestamp function to provide the units specified in `time_unit`.

**It is NOT tested without the `devmode`**, because I have not been able to use the `packet-sender` without the devmode.  