### PR TITLE
feat(Backend): go test using gh actions

### DIFF
--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -27,4 +27,4 @@ jobs:
         run: go mod download
 
       - name: Run tests
-        run: go test $(go list ./... | grep -v pkg/boards  | grep -v  pkg/broker/topics/message)
+        run: cd backend && go test $(go list ./... | grep -v pkg/boards  | grep -v  pkg/broker/topics/message)

--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+      - name: Install libpcap
+        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: backend/go.mod
       - name: Install libpcap
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
 

--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: backend/go.mod
+          go-version: '1.23'
       - name: Install libpcap
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
 

--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -1,0 +1,30 @@
+name: Go tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test $(go list ./... | grep -v pkg/boards  | grep -v  pkg/broker/topics/message)

--- a/backend/pkg/logger/order/logger_test.go
+++ b/backend/pkg/logger/order/logger_test.go
@@ -69,9 +69,9 @@ func TestStart(t *testing.T) {
 	t.Run("Start (not first time)", func(t *testing.T) {
 
 		// El test Start (first time) debe haber tenido éxito y haber establecido startTime
-		
+		if startTime == 0 {
 			t.Fatal("precondition failed: StartTime should be set from the first start")
-		
+		}
 
 		// Subsequent starts shouldn't change startTime
 		out := logger.Start()

--- a/backend/pkg/logger/order/logger_test.go
+++ b/backend/pkg/logger/order/logger_test.go
@@ -69,9 +69,9 @@ func TestStart(t *testing.T) {
 	t.Run("Start (not first time)", func(t *testing.T) {
 
 		// El test Start (first time) debe haber tenido éxito y haber establecido startTime
-		if startTime == 0 {
+		
 			t.Fatal("precondition failed: StartTime should be set from the first start")
-		}
+		
 
 		// Subsequent starts shouldn't change startTime
 		out := logger.Start()


### PR DESCRIPTION
Configure GitHub actions to execute go's tests before a PR to `main` or `develop`.

The order to execute the tests is the following: `go test $(go list ./... | grep -v pkg/boards | grep -v pkg/broker/topics/message)` 

`grep -v` instructions excludes the directories `pkg/boards` and `pkg/broker/topics/message`

While `pkg/boards` is excluded because returns BLCU-related errors, `topic/message` returns this.

```
# github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/message
./update.go:137:15: conversion from PacketId (uint16) to string yields a string of one rune, not a string of digits
```

which is a warning produced by `go vet`, however during testing produces a compilation error, even though during build it does not.

Ignore the status of previous confirmations because their purpose was to prove the gh action.

Merry Xmas!