### PR TITLE
fix(backend): remove tcp try reconnect

### DIFF
--- a/backend/pkg/transport/network/tcp/client.go
+++ b/backend/pkg/transport/network/tcp/client.go
@@ -62,12 +62,6 @@ func (client *Client) Dial() (net.Conn, error) {
 			client.logger.Error().Stack().Err(client.config.Context.Err()).Msg("canceled")
 			return nil, client.config.Context.Err()
 		}
-
-		// If reconnection is disabled, bail out immediately on any error
-		if !client.config.TryReconnect {
-			client.logger.Error().Stack().Err(err).Msg("failed with non-retryable error")
-			return nil, err
-		}
 	}
 
 	client.logger.Debug().Int("max", client.config.MaxConnectionRetries).Msg("max connection retries exceeded")

--- a/backend/pkg/transport/network/tcp/config.go
+++ b/backend/pkg/transport/network/tcp/config.go
@@ -13,7 +13,6 @@ type ClientConfig struct {
 
 	Context context.Context
 
-	TryReconnect              bool
 	ConnectionBackoffFunction backoffFunction
 	MaxConnectionRetries      int
 }
@@ -34,7 +33,6 @@ func NewClientConfig(laddr net.Addr) ClientConfig {
 		},
 
 		Context:                   context.TODO(),
-		TryReconnect:              true,
 		ConnectionBackoffFunction: NewExponentialBackoff(defaultBackoffMin, defaultBackoffExp, defaultBackoffMax),
 		MaxConnectionRetries:      -1,
 	}

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -55,20 +55,11 @@ func (transport *Transport) HandleClient(config tcp.ClientConfig, remote string)
 	client := tcp.NewClient(remote, config, transport.logger)
 	clientLogger := transport.logger.With().Str("remoteAddress", remote).Logger()
 	defer clientLogger.Warn().Msg("abort connection")
-	hasConnected := false
 
 	for {
 		conn, err := client.Dial()
 		if err != nil {
 			clientLogger.Debug().Stack().Err(err).Msg("dial failed")
-			// Only return if reconnection is disabled
-			if !config.TryReconnect {
-				if hasConnected {
-					transport.SendFault()
-				}
-				transport.errChan <- err
-				return err
-			}
 
 			// For ErrTooManyRetries, we still want to continue retrying
 			// The client will reset its retry counter on the next Dial() call
@@ -81,8 +72,6 @@ func (transport *Transport) HandleClient(config tcp.ClientConfig, remote string)
 			continue
 		}
 
-		hasConnected = true
-
 		err = transport.handleTCPConn(conn)
 		if errors.Is(err, error(ErrTargetAlreadyConnected{})) {
 			clientLogger.Warn().Stack().Err(err).Msg("multiple connections for same target")
@@ -91,11 +80,6 @@ func (transport *Transport) HandleClient(config tcp.ClientConfig, remote string)
 		}
 		if err != nil {
 			clientLogger.Debug().Stack().Err(err).Msg("connection lost")
-			if !config.TryReconnect {
-				transport.SendFault()
-				transport.errChan <- err
-				return err
-			}
 
 			// Connection was lost, continue trying to reconnect
 			continue


### PR DESCRIPTION
Remove TCP client try reconnect because was always set to `true` and there is no intention to add it to settings

