### PR TITLE
feat(logging-view): double sidebar toggle handle size

### DIFF
--- a/frontend/logging-view/src/components/sidebar/SidebarToggleHandle.tsx
+++ b/frontend/logging-view/src/components/sidebar/SidebarToggleHandle.tsx
@@ -19,10 +19,10 @@ const SidebarToggleHandle = () => {
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 sm:flex",
-        "group-data-[side=left]:-right-4 group-data-[side=right]:left-0",
+        "absolute inset-y-0 z-20 hidden w-8 -translate-x-1/2 sm:flex",
+        "group-data-[side=left]:-right-8 group-data-[side=right]:left-0",
         "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-4",
         "flex-col items-center justify-center",
         "cursor-pointer border-0 bg-transparent p-0 outline-none",
       )}
@@ -43,21 +43,21 @@ const SidebarToggleHandle = () => {
                                left is hidden behind the screen boundary. */}
       <div
         className={cn(
-          "relative z-10 flex items-center rounded-md p-1",
+          "relative z-10 flex items-center rounded-md p-2",
           "border bg-sidebar shadow-md transition-colors duration-150",
           hovered ? "border-primary/40" : "border-border/60",
         )}
       >
         <ChevronLeft
           className={cn(
-            "size-4 transition-colors duration-150",
+            "size-8 transition-colors duration-150",
             hovered ? "text-primary/70" : "text-muted-foreground/40",
           )}
         />
         {!isOpen && (
           <ChevronRight
             className={cn(
-              "-ml-2 size-4 transition-colors duration-150",
+              "-ml-4 size-8 transition-colors duration-150",
               hovered ? "text-primary/70" : "text-muted-foreground/40",
             )}
           />

--- a/frontend/logging-view/src/components/simple/plots/PlotWrapper.tsx
+++ b/frontend/logging-view/src/components/simple/plots/PlotWrapper.tsx
@@ -10,7 +10,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@workspace/ui/components";
-import { Activity, AlertTriangle, Pencil, RefreshCw, Trash2 } from "@workspace/ui/icons";
+import { Activity, AlertTriangle, ChevronDown, Pencil, RefreshCw, Trash2 } from "@workspace/ui/icons";
 import Plotly from "plotly.js-dist";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { computeFFT } from "../../../lib/plotStudio/fft";
@@ -105,6 +105,7 @@ export default function PlotWrapper({ plot }: PlotWrapperProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [plotHeight, setPlotHeight] = useState(500);
   const [showStats, setShowStats]   = useState(false);
+  const [collapsed, setCollapsed]   = useState(false);
 
   // Inline rename
   const [editingName, setEditingName] = useState(false);
@@ -335,6 +336,12 @@ export default function PlotWrapper({ plot }: PlotWrapperProps) {
 
       {/* Header */}
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2.5">
+        <Button variant="ghost" size="icon-sm" onClick={() => setCollapsed((v) => !v)}
+          aria-label={collapsed ? "Expand plot" : "Collapse plot"}
+          className="text-muted-foreground hover:text-foreground hover:bg-muted -ml-1.5 shrink-0">
+          <ChevronDown className={`size-5 transition-transform ${collapsed ? "-rotate-90" : ""}`} />
+        </Button>
+
         <div className="flex min-w-0 items-center gap-2">
           <Activity className="text-primary size-4 shrink-0" />
 
@@ -444,39 +451,43 @@ export default function PlotWrapper({ plot }: PlotWrapperProps) {
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant="ghost" size="icon-xs" onClick={() => removeStudioPlot(plot.id)}
-                aria-label="Delete plot"
+                aria-label="Close plot"
                 className="text-muted-foreground hover:text-destructive hover:bg-destructive/10">
                 <Trash2 className="size-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Delete plot</TooltipContent>
+            <TooltipContent>Close plot</TooltipContent>
           </Tooltip>
         </div>
       </div>
 
-      {hasTraces ? (
-        // Chart — white canvas kept intentionally for the academic/LaTeX export style
-        <div ref={containerRef} className="relative bg-white" style={{ height: plotHeight }}>
-          <PlotlyChart ref={chartRef} traces={traces} layout={layout} config={PLOTLY_CONFIG} style={{ height: "100%" }} />
-          <div
-            onMouseDown={onResizeMouseDown}
-            className="hover:bg-primary/10 group absolute inset-x-0 bottom-0 flex h-3 cursor-ns-resize items-center justify-center"
-          >
-            <div className="bg-border group-hover:bg-primary/50 h-0.5 w-12 rounded-full transition-colors" />
+      {/* Kept mounted (not conditionally removed) while collapsed, so Plotly's
+          zoom/pan state and WebGL context survive expand/collapse. */}
+      <div className={collapsed ? "hidden" : undefined}>
+        {hasTraces ? (
+          // Chart — white canvas kept intentionally for the academic/LaTeX export style
+          <div ref={containerRef} className="relative bg-white" style={{ height: plotHeight }}>
+            <PlotlyChart ref={chartRef} traces={traces} layout={layout} config={PLOTLY_CONFIG} style={{ height: "100%" }} />
+            <div
+              onMouseDown={onResizeMouseDown}
+              className="hover:bg-primary/10 group absolute inset-x-0 bottom-0 flex h-3 cursor-ns-resize items-center justify-center"
+            >
+              <div className="bg-border group-hover:bg-primary/50 h-0.5 w-12 rounded-full transition-colors" />
+            </div>
           </div>
-        </div>
-      ) : (
-        <div className="border-muted-foreground/20 bg-muted/20 m-4 mt-1 flex h-40 flex-col items-center justify-center gap-2 rounded-lg border border-dashed">
-          <Activity className="text-muted-foreground/40 size-6" />
-          <p className="text-muted-foreground text-xs">
-            No signals to display — assign one from the <span className="text-foreground font-medium">Plots</span> panel
-          </p>
-        </div>
-      )}
+        ) : (
+          <div className="border-muted-foreground/20 bg-muted/20 m-4 mt-1 flex h-40 flex-col items-center justify-center gap-2 rounded-lg border border-dashed">
+            <Activity className="text-muted-foreground/40 size-6" />
+            <p className="text-muted-foreground text-xs">
+              No signals to display — assign one from the <span className="text-foreground font-medium">Plots</span> panel
+            </p>
+          </div>
+        )}
 
-      {showStats && hasTraces && (
-        <StatsPanel signalData={statsData} getVisibleRange={getVisibleRange} onClose={() => setShowStats(false)} />
-      )}
+        {showStats && hasTraces && (
+          <StatsPanel signalData={statsData} getVisibleRange={getVisibleRange} onClose={() => setShowStats(false)} />
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/logging-view/src/components/simple/plots/PlotsArea.tsx
+++ b/frontend/logging-view/src/components/simple/plots/PlotsArea.tsx
@@ -51,14 +51,19 @@ function EmptyState() {
 export default function PlotsArea() {
   const studioPlots = useStore((s) => s.studioPlots);
   const plots = Array.from(studioPlots.values());
+  const visiblePlots = plots.filter((plot) => !plot.hidden);
 
   if (plots.length === 0) return <EmptyState />;
 
   return (
     <div className="flex flex-col gap-5 p-4">
-      {plots.map((plot) => (
-        <PlotWrapper key={plot.id} plot={plot} />
-      ))}
+      {visiblePlots.length === 0 ? (
+        <p className="text-muted-foreground py-8 text-center text-sm">
+          All plots are hidden — unhide one from the right panel to see it here.
+        </p>
+      ) : (
+        visiblePlots.map((plot) => <PlotWrapper key={plot.id} plot={plot} />)
+      )}
     </div>
   );
 }

--- a/frontend/logging-view/src/components/simple/sidebar/PlotsSection.tsx
+++ b/frontend/logging-view/src/components/simple/sidebar/PlotsSection.tsx
@@ -12,7 +12,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@workspace/ui/components";
-import { Activity, Plus, Trash2, X } from "@workspace/ui/icons";
+import { Activity, Eye, EyeOff, GripVertical, Plus, Trash2, X } from "@workspace/ui/icons";
 import { cn } from "@workspace/ui/lib";
 import { useState } from "react";
 import { resolveSignalColor } from "../../../lib/plotStudio/palette";
@@ -29,6 +29,8 @@ export default function PlotsSection() {
   const adjData = useStore((s) => s.adjData);
   const addStudioPlot              = useStore((s) => s.addStudioPlot);
   const removeStudioPlot           = useStore((s) => s.removeStudioPlot);
+  const toggleStudioPlotHidden     = useStore((s) => s.toggleStudioPlotHidden);
+  const reorderStudioPlots         = useStore((s) => s.reorderStudioPlots);
   const addSignalToStudioPlot      = useStore((s) => s.addSignalToStudioPlot);
   const removeSignalFromStudioPlot = useStore((s) => s.removeSignalFromStudioPlot);
   const updateStudioSignalAxis     = useStore((s) => s.updateStudioSignalAxis);
@@ -38,8 +40,20 @@ export default function PlotsSection() {
   const ensureLoaded = useSignalLoader();
   // Plot ids with a CSV parse in flight (shows "Loading…" in the trigger)
   const [assigning, setAssigning] = useState<Set<string>>(new Set());
+  // Drag-to-reorder: id of the plot currently being dragged
+  const [draggingId, setDraggingId] = useState<string | null>(null);
 
   const plots = Array.from(studioPlots.values());
+
+  const handleDrop = (targetId: string) => {
+    if (!draggingId || draggingId === targetId) return;
+    const ids = plots.map((p) => p.id);
+    const from = ids.indexOf(draggingId);
+    const to = ids.indexOf(targetId);
+    ids.splice(to, 0, ids.splice(from, 1)[0]);
+    reorderStudioPlots(ids);
+    setDraggingId(null);
+  };
 
   const shortName = (id: string) =>
     id.includes("/") ? id.split("/").slice(1).join("/") : id.replace(/\.csv$/, "");
@@ -68,9 +82,23 @@ export default function PlotsSection() {
       )}
 
       {plots.map((plot) => (
-        <div key={plot.id} className="bg-card overflow-hidden rounded-lg border shadow-sm">
-          {/* Plot header */}
-          <div className="from-primary/5 flex items-center gap-2 border-b bg-gradient-to-r to-transparent px-3 py-2">
+        <div key={plot.id}
+          className={cn(
+            "bg-card overflow-hidden rounded-lg border shadow-sm transition-opacity",
+            plot.hidden && "opacity-50",
+            draggingId === plot.id && "opacity-30",
+          )}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={() => handleDrop(plot.id)}
+        >
+          {/* Plot header — draggable to reorder plots (reflected in PlotsArea too) */}
+          <div
+            draggable
+            onDragStart={() => setDraggingId(plot.id)}
+            onDragEnd={() => setDraggingId(null)}
+            className="from-primary/5 flex cursor-grab items-center gap-2 border-b bg-gradient-to-r to-transparent px-3 py-2 active:cursor-grabbing"
+          >
+            <GripVertical className="text-muted-foreground/50 size-3.5 shrink-0" />
             <div className="bg-primary/20 flex size-4 shrink-0 items-center justify-center rounded-sm">
               <Activity className="text-primary size-3" />
             </div>
@@ -78,13 +106,24 @@ export default function PlotsSection() {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="ghost" size="icon-xs"
+                  onClick={() => toggleStudioPlotHidden(plot.id)}
+                  aria-label={plot.hidden ? `Show ${plot.name}` : `Hide ${plot.name}`}
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted">
+                  {plot.hidden ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="left">{plot.hidden ? "Show plot" : "Hide plot"}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon-xs"
                   onClick={() => removeStudioPlot(plot.id)}
-                  aria-label={`Remove ${plot.name}`}
+                  aria-label={`Close ${plot.name}`}
                   className="text-muted-foreground hover:text-destructive hover:bg-destructive/10">
                   <X className="size-3.5" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent side="left">Remove plot</TooltipContent>
+              <TooltipContent side="left">Close plot</TooltipContent>
             </Tooltip>
           </div>
 

--- a/frontend/logging-view/src/store/slices/plotStudioSlice.ts
+++ b/frontend/logging-view/src/store/slices/plotStudioSlice.ts
@@ -26,6 +26,8 @@ export interface PlotStudioSlice {
   addStudioPlot: () => void;
   removeStudioPlot: (id: string) => void;
   renameStudioPlot: (id: string, name: string) => void;
+  toggleStudioPlotHidden: (id: string) => void;
+  reorderStudioPlots: (orderedIds: string[]) => void;
   addSignalToStudioPlot: (plotId: string, signalId: string) => void;
   removeSignalFromStudioPlot: (plotId: string, signalId: string) => void;
   updateStudioSignalAxis: (plotId: string, signalId: string, axis: "left" | "right") => void;
@@ -131,6 +133,30 @@ export const createPlotStudioSlice: StateCreator<PlotStudioSlice> = (set) => ({
       if (!plot || !trimmed) return {};
       const next = new Map(s.studioPlots);
       next.set(id, { ...plot, name: trimmed });
+      return { studioPlots: next };
+    }),
+
+  toggleStudioPlotHidden: (id) =>
+    set((s) => {
+      const plot = s.studioPlots.get(id);
+      if (!plot) return {};
+      const next = new Map(s.studioPlots);
+      next.set(id, { ...plot, hidden: !plot.hidden });
+      return { studioPlots: next };
+    }),
+
+  // Rebuilds the Map in the given key order — Maps iterate in insertion
+  // order, so this is how plot order (sidebar list + PlotsArea) is changed.
+  reorderStudioPlots: (orderedIds) =>
+    set((s) => {
+      const next = new Map<string, PlotState>();
+      for (const id of orderedIds) {
+        const plot = s.studioPlots.get(id);
+        if (plot) next.set(id, plot);
+      }
+      s.studioPlots.forEach((plot, id) => {
+        if (!next.has(id)) next.set(id, plot);
+      });
       return { studioPlots: next };
     }),
 

--- a/frontend/logging-view/src/types/plotStudio.ts
+++ b/frontend/logging-view/src/types/plotStudio.ts
@@ -57,6 +57,7 @@ export interface PlotState {
   id: string;   // DOM element ID ("plot_0", "plot_1", …)
   name: string;
   signals: PlotSignal[];
+  hidden?: boolean; // if true, skipped in PlotsArea but still managed in the sidebar list
 }
 
 /** Summary statistics for a signal over a time range. */


### PR DESCRIPTION
## Summary
- Doubles the sidebar toggle handle's clickable hit-area, icon badge, and chevron icons (all Tailwind size classes scaled 2x, offsets adjusted to match).

## Test plan
- [x] Run `pnpm dev --filter logging-view`, verify the toggle handle on the sidebar edge is visibly larger and still opens/closes correctly on click and hover.