### PR TITLE
fix(ui): stop sidebar separator line from overflowing past the panel edge

### DIFF
--- a/frontend/frontend-kit/ui/src/components/shadcn/sidebar.tsx
+++ b/frontend/frontend-kit/ui/src/components/shadcn/sidebar.tsx
@@ -362,7 +362,7 @@ function SidebarSeparator({
     <Separator
       data-slot="sidebar-separator"
       data-sidebar="separator"
-      className={cn("bg-sidebar-border mx-2 w-auto", className)}
+      className={cn("bg-sidebar-border mx-2 data-[orientation=horizontal]:w-auto", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- In the logging-view sidebar, the horizontal `SidebarSeparator` between the "Session" and "Series" groups rendered past the sidebar's right border by ~7-8px instead of stopping with an `mx-2` margin like the rest of the panel content.
- Root cause: the shared `Separator` primitive (`frontend-kit/ui/src/components/shadcn/separator.tsx`) sets `data-[orientation=horizontal]:w-full`. `SidebarSeparator` tried to override it with a plain `w-auto`, but since the base class is scoped to a `data-orientation` attribute selector, it wins on CSS specificity regardless of class order — so `mx-2`'s margins were added on top of a still-full-width element, pushing the line's right edge outside the sidebar.
- Fix: scope the override to the same `data-[orientation=horizontal]` modifier so tailwind-merge treats it as the same utility group and actually replaces `w-full` with `w-auto`.
- This is a shared `@workspace/ui` component, so the fix also applies anywhere else `SidebarSeparator` is used (competition-view, testing-view), not just logging-view.

## Test plan
- [x] Verified via a Playwright script measuring `getBoundingClientRect()`: before the fix the separator spanned `left:8, right:287` inside a `280`px-wide sidebar container (7px overflow); after the fix it spans `left:8, right:271` (correctly inset on both sides).
- [x] Confirmed visually with before/after screenshots — the separator no longer pokes out past the sidebar's vertical border.
- [x] `pnpm --filter @workspace/ui lint` — no new warnings/errors (pre-existing warnings unrelated to this change).
- [x] `pnpm --filter logging-view build` — same pre-existing type errors as on the base branch (scaffold app, not introduced by this change); no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)