### PR TITLE
feat(logging-view, simple): dark-mode theming for Plotly charts

### DIFF
--- a/frontend/logging-view/src/components/simple/plots/PlotWrapper.tsx
+++ b/frontend/logging-view/src/components/simple/plots/PlotWrapper.tsx
@@ -18,6 +18,7 @@ import { decimateLTTB } from "../../../lib/plotStudio/decimate";
 import { decodeSignalIds, SIGNAL_IDS_MIME } from "../../../lib/plotStudio/dnd";
 import { computeFFT } from "../../../lib/plotStudio/fft";
 import { resolveSignalColor } from "../../../lib/plotStudio/palette";
+import { buildPlotLayout, getPlotlyTheme } from "../../../lib/plotStudio/plotlyTheme";
 import { lowerBound, upperBound } from "../../../lib/plotStudio/range";
 import { commonUnits, getSignalName, getSignalUnits, unitsMismatch } from "../../../lib/plotStudio/units";
 import { displayName, getSignalData } from "../../../store/slices/plotStudioSlice";
@@ -107,6 +108,7 @@ export default function PlotWrapper({ plot }: PlotWrapperProps) {
   const adjData = useStore((s) => s.adjData);
   const removeStudioPlot = useStore((s) => s.removeStudioPlot);
   const renameStudioPlot = useStore((s) => s.renameStudioPlot);
+  const isDarkMode = useStore((s) => s.isDarkMode);
   const assignSignalsToPlot = useAssignSignalsToPlot();
 
   const chartRef     = useRef<PlotlyChartHandle>(null);
@@ -266,66 +268,12 @@ export default function PlotWrapper({ plot }: PlotWrapperProps) {
   const hasTraces = traces.length > 0;
 
   const layout = useMemo<Partial<Plotly.Layout>>(
-    () => {
-      const leftUnits  = axisUnits.left;
-      const rightUnits = axisUnits.right;
-
-      const base: Partial<Plotly.Layout> = {
-        autosize: true,
-        // Preserve zoom/pan across data changes (adding signals, stats, etc.);
-        // reset only when the X-axis meaning flips between time and frequency.
-        uirevision: hasFFT ? `${plot.id}:fft` : plot.id,
-        paper_bgcolor: "white", plot_bgcolor: "white",
-        font: { color: "#000000", family: "Computer Modern, Latin Modern Math, Times New Roman, serif", size: 14 },
-        // Plot title stays editable (click-to-enter placeholder); the subtitle
-        // line is explicitly blanked so it doesn't show its own placeholder.
-        title: { subtitle: { text: "" } },
-        xaxis: {
-          title: { text: hasFFT ? "Frequency (Hz)" : "Time (ms)", font: { size: 16, color: "#000000" } },
-          gridcolor: "#e0e0e0", linecolor: "#000000", linewidth: 1.5, mirror: true,
-          ticks: "outside", tickwidth: 1.5, tickcolor: "#000000", color: "#000000",
-          showline: true, zeroline: false, fixedrange: false,
-          exponentformat: "power", separatethousands: true,
-        },
-        yaxis: {
-          title: {
-            text: hasRightAxis
-              ? `Value (Left${leftUnits ? `, ${leftUnits}` : ""})`
-              : `Value${leftUnits ? ` (${leftUnits})` : ""}`,
-            font: { size: 16, color: hasRightAxis ? "#1f77b4" : "#000000" },
-          },
-          gridcolor: "#e0e0e0", linecolor: hasRightAxis ? "#1f77b4" : "#000000", linewidth: 1.5, mirror: !hasRightAxis,
-          ticks: "outside", tickwidth: 1.5, tickcolor: hasRightAxis ? "#1f77b4" : "#000000", color: hasRightAxis ? "#1f77b4" : "#000000",
-          showline: true, zeroline: false, fixedrange: false,
-          exponentformat: "power", separatethousands: true,
-        },
-        margin: { l: 80, r: hasRightAxis ? 80 : 40, t: 40, b: 130 },
-        // Unified hover: one label per signal at the same X — much easier to
-        // compare synchronized measurements than per-point "closest" mode.
-        hovermode: "x unified",
-        hoverlabel: {
-          bgcolor: "rgba(255,255,255,0.97)",
-          bordercolor: "#000000",
-          font: { family: "Computer Modern, Latin Modern Math, Times New Roman, serif", size: 12, color: "#000000" },
-        },
-        showlegend: true,
-        legend: {
-          bgcolor: "rgba(255,255,255,0.95)", bordercolor: "#000000", borderwidth: 1, font: { size: 13, color: "#000000" },
-          orientation: "h", x: 1, xanchor: "right", y: -0.35, yanchor: "top",
-        },
-      };
-      if (hasRightAxis) {
-        base.yaxis2 = {
-          title: { text: `Value (Right${rightUnits ? `, ${rightUnits}` : ""})`, font: { size: 16, color: "#ff7f0e" } },
-          overlaying: "y", side: "right", gridcolor: "transparent",
-          linecolor: "#ff7f0e", linewidth: 1.5, ticks: "outside", tickwidth: 1.5,
-          tickcolor: "#ff7f0e", color: "#ff7f0e", showline: true, zeroline: false, fixedrange: false,
-          exponentformat: "power", separatethousands: true,
-        };
-      }
-      return base;
-    },
-    [hasRightAxis, hasFFT, plot.id, axisUnits],
+    () => buildPlotLayout({
+      theme: getPlotlyTheme(isDarkMode),
+      hasFFT, hasRightAxis, plotId: plot.id,
+      leftUnits: axisUnits.left, rightUnits: axisUnits.right,
+    }),
+    [hasRightAxis, hasFFT, plot.id, axisUnits, isDarkMode],
   );
 
   // Drag-to-resize
@@ -407,19 +355,40 @@ export default function PlotWrapper({ plot }: PlotWrapperProps) {
     Plotly.relayout(div, { "xaxis.autorange": true, "yaxis.autorange": true, "yaxis2.autorange": true });
   }, []);
 
-  const exportSVG = () => {
+  // Exports always render in the light/academic theme regardless of the
+  // on-screen app theme (publication-figure look), but keep whatever
+  // zoom/pan range is currently visible rather than autoranging to all data.
+  const buildExportFigure = () => {
     const div = chartRef.current?.getDiv();
-    if (!div) return;
-    Plotly.toImage(div, { format: "svg", width: 1200, height: 800 }).then((url) => {
+    if (!div) return null;
+    const gd = div as unknown as Plotly.PlotlyHTMLElement & { _fullLayout: Record<string, { range?: number[] }> };
+    const exportLayout = buildPlotLayout({
+      theme: getPlotlyTheme(false),
+      hasFFT, hasRightAxis, plotId: plot.id,
+      leftUnits: axisUnits.left, rightUnits: axisUnits.right,
+    });
+    const xRange  = gd._fullLayout["xaxis"]?.range;
+    const yRange  = gd._fullLayout["yaxis"]?.range;
+    const y2Range = gd._fullLayout["yaxis2"]?.range;
+    if (xRange) exportLayout.xaxis = { ...exportLayout.xaxis, range: xRange, autorange: false };
+    if (yRange) exportLayout.yaxis = { ...exportLayout.yaxis, range: yRange, autorange: false };
+    if (y2Range && exportLayout.yaxis2) exportLayout.yaxis2 = { ...exportLayout.yaxis2, range: y2Range, autorange: false };
+    return { data: gd.data, layout: exportLayout };
+  };
+
+  const exportSVG = () => {
+    const figure = buildExportFigure();
+    if (!figure) return;
+    Plotly.toImage(figure, { format: "svg", width: 1200, height: 800 }).then((url) => {
       const a = document.createElement("a");
       a.href = url; a.download = `${plot.name}_${Date.now()}.svg`; a.click();
     });
   };
 
   const exportPNG = () => {
-    const div = chartRef.current?.getDiv();
-    if (!div) return;
-    Plotly.downloadImage(div, { format: "png", width: 2400, height: 1600, scale: 2, filename: `${plot.name}_${Date.now()}` });
+    const figure = buildExportFigure();
+    if (!figure) return;
+    Plotly.downloadImage(figure, { format: "png", width: 2400, height: 1600, scale: 2, filename: `${plot.name}_${Date.now()}` });
   };
 
   const statsData = useMemo(
@@ -581,8 +550,9 @@ export default function PlotWrapper({ plot }: PlotWrapperProps) {
           zoom/pan state and WebGL context survive expand/collapse. */}
       <div className={collapsed ? "hidden" : undefined}>
         {hasTraces ? (
-          // Chart — white canvas kept intentionally for the academic/LaTeX export style
-          <div ref={containerRef} className="relative bg-white" style={{ height: plotHeight }}>
+          // Chart canvas follows app dark mode; exports stay pinned to the
+          // light/academic theme regardless (see buildExportFigure above).
+          <div ref={containerRef} className="relative" style={{ height: plotHeight, backgroundColor: isDarkMode ? "#181818" : "white" }}>
             <PlotlyChart ref={chartRef} traces={traces} layout={layout} config={PLOTLY_CONFIG} style={{ height: "100%" }} />
             <div
               onMouseDown={onResizeMouseDown}

--- a/frontend/logging-view/src/lib/plotStudio/plotlyTheme.ts
+++ b/frontend/logging-view/src/lib/plotStudio/plotlyTheme.ts
@@ -1,0 +1,117 @@
+// Plotly has no built-in dark/light theming — every color is a literal in
+// `layout`. This module is the single source of truth for those colors and
+// for the structural layout built from them, so the live chart (theme-
+// following) and image exports (always forced light, see PlotWrapper) build
+// the exact same shape from two different theme instances.
+import type Plotly from "plotly.js-dist";
+
+export interface PlotlyThemeColors {
+  paperBg: string;
+  plotBg: string;
+  fontColor: string;
+  gridColor: string;
+  neutralLineColor: string;
+  hoverBg: string;
+  hoverBorder: string;
+  hoverFontColor: string;
+  legendBg: string;
+  legendBorder: string;
+  legendFontColor: string;
+  modebar?: { bgcolor: string; color: string; activecolor: string };
+}
+
+const FONT_FAMILY = "Computer Modern, Latin Modern Math, Times New Roman, serif";
+
+// Dual-axis accent colors are identical in both themes — both read fine on
+// white and on the app's dark background.
+const LEFT_AXIS_ACCENT  = "#1f77b4";
+const RIGHT_AXIS_ACCENT = "#ff7f0e";
+
+export function getPlotlyTheme(isDarkMode: boolean): PlotlyThemeColors {
+  if (!isDarkMode) {
+    return {
+      paperBg: "white", plotBg: "white",
+      fontColor: "#000000", gridColor: "#e0e0e0", neutralLineColor: "#000000",
+      hoverBg: "rgba(255,255,255,0.97)", hoverBorder: "#000000", hoverFontColor: "#000000",
+      legendBg: "rgba(255,255,255,0.95)", legendBorder: "#000000", legendFontColor: "#000000",
+    };
+  }
+  return {
+    paperBg: "#181818", plotBg: "#181818",
+    fontColor: "#f9fafb", gridColor: "#404040", neutralLineColor: "#f9fafb",
+    hoverBg: "rgba(24,24,24,0.95)", hoverBorder: "#404040", hoverFontColor: "#f9fafb",
+    legendBg: "rgba(24,24,24,0.9)", legendBorder: "#404040", legendFontColor: "#f9fafb",
+    modebar: { bgcolor: "rgba(24,24,24,0)", color: "#b5b5b5", activecolor: "#ff7f24" },
+  };
+}
+
+export interface BuildPlotLayoutParams {
+  theme: PlotlyThemeColors;
+  hasFFT: boolean;
+  hasRightAxis: boolean;
+  plotId: string;
+  leftUnits: string | undefined;
+  rightUnits: string | undefined;
+}
+
+export function buildPlotLayout({
+  theme, hasFFT, hasRightAxis, plotId, leftUnits, rightUnits,
+}: BuildPlotLayoutParams): Partial<Plotly.Layout> {
+  const base: Partial<Plotly.Layout> = {
+    autosize: true,
+    // Preserve zoom/pan across data changes (adding signals, stats, etc.);
+    // reset only when the X-axis meaning flips between time and frequency.
+    uirevision: hasFFT ? `${plotId}:fft` : plotId,
+    paper_bgcolor: theme.paperBg, plot_bgcolor: theme.plotBg,
+    font: { color: theme.fontColor, family: FONT_FAMILY, size: 14 },
+    // Plot title stays editable (click-to-enter placeholder); the subtitle
+    // line is explicitly blanked so it doesn't show its own placeholder.
+    title: { subtitle: { text: "" } },
+    xaxis: {
+      title: { text: hasFFT ? "Frequency (Hz)" : "Time (ms)", font: { size: 16, color: theme.fontColor } },
+      gridcolor: theme.gridColor, linecolor: theme.neutralLineColor, linewidth: 1.5, mirror: true,
+      ticks: "outside", tickwidth: 1.5, tickcolor: theme.neutralLineColor, color: theme.neutralLineColor,
+      showline: true, zeroline: false, fixedrange: false,
+      exponentformat: "power", separatethousands: true,
+    },
+    yaxis: {
+      title: {
+        text: hasRightAxis
+          ? `Value (Left${leftUnits ? `, ${leftUnits}` : ""})`
+          : `Value${leftUnits ? ` (${leftUnits})` : ""}`,
+        font: { size: 16, color: hasRightAxis ? LEFT_AXIS_ACCENT : theme.fontColor },
+      },
+      gridcolor: theme.gridColor, linecolor: hasRightAxis ? LEFT_AXIS_ACCENT : theme.neutralLineColor, linewidth: 1.5, mirror: !hasRightAxis,
+      ticks: "outside", tickwidth: 1.5, tickcolor: hasRightAxis ? LEFT_AXIS_ACCENT : theme.neutralLineColor, color: hasRightAxis ? LEFT_AXIS_ACCENT : theme.neutralLineColor,
+      showline: true, zeroline: false, fixedrange: false,
+      exponentformat: "power", separatethousands: true,
+    },
+    margin: { l: 80, r: hasRightAxis ? 80 : 40, t: 40, b: 130 },
+    // Unified hover: one label per signal at the same X — much easier to
+    // compare synchronized measurements than per-point "closest" mode.
+    hovermode: "x unified",
+    hoverlabel: {
+      bgcolor: theme.hoverBg,
+      bordercolor: theme.hoverBorder,
+      font: { family: FONT_FAMILY, size: 12, color: theme.hoverFontColor },
+    },
+    showlegend: true,
+    legend: {
+      bgcolor: theme.legendBg, bordercolor: theme.legendBorder, borderwidth: 1, font: { size: 13, color: theme.legendFontColor },
+      orientation: "h", x: 1, xanchor: "right", y: -0.35, yanchor: "top",
+    },
+  };
+  if (theme.modebar) {
+    base.modebar = theme.modebar;
+  }
+  if (hasRightAxis) {
+    base.yaxis2 = {
+      title: { text: `Value (Right${rightUnits ? `, ${rightUnits}` : ""})`, font: { size: 16, color: RIGHT_AXIS_ACCENT } },
+      overlaying: "y", side: "right", gridcolor: "transparent",
+      linecolor: RIGHT_AXIS_ACCENT, linewidth: 1.5, ticks: "outside", tickwidth: 1.5,
+      tickcolor: RIGHT_AXIS_ACCENT, color: RIGHT_AXIS_ACCENT, showline: true, zeroline: false, fixedrange: false,
+      exponentformat: "power", separatethousands: true,
+    };
+  }
+  return base;
+}


### PR DESCRIPTION
## Summary
- Plotly has no built-in dark/light theming; the Plot Studio chart (`PlotWrapper.tsx`) was hardcoded to a white/black "academic" style regardless of app theme.
- The chart now follows `isDarkMode` (paper/plot background, grid, axis, legend, hover, and modebar colors), extracted into a reusable `getPlotlyTheme`/`buildPlotLayout` pair in the new `lib/plotStudio/plotlyTheme.ts`.
- SVG/PNG exports always stay pinned to the light/academic theme (Computer Modern serif, white background) regardless of the on-screen mode, to preserve the publication-figure look — while still exporting whatever zoom/pan range is currently visible instead of autoranging to all data.
- Dual-axis accent colors (`#1f77b4` blue, `#ff7f0e` orange) are unchanged in both themes.

## Test plan
- [x] `pnpm --filter logging-view lint` — 0 errors (pre-existing warnings only, all in the untouched legacy `plot_gui_web/app.js` prototype).
- [x] `tsc -b` — no new type errors from this change (verified by diffing against the same 4 pre-existing errors present on `control-station/logging-view` before this PR, e.g. an existing `downloadImage` `scale` option, an existing `yaxis2.autorange` relayout call, and existing HTMLDivElement→PlotlyHTMLElement casts elsewhere in the file).
- [x] Manually drove the dev server with Playwright + a synthetic session (CSV signal): confirmed the chart flips between white/black and dark (`#181818`/light-gray) when toggling dark mode, with legend/hover/grid recoloring correctly and no console errors.
- [x] Verified a dual-axis plot (left signal + right-axis signal) renders legibly in dark mode.
- [x] Verified SVG export while the app is in dark mode still produces a white/black-themed SVG (inspected exported markup for `rgb(255,255,255)` / `rgb(0,0,0)`, no dark colors present).